### PR TITLE
feat: add basic embeddings db

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -1,10 +1,12 @@
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["postgresqlExtensions"]
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider   = "postgresql"
+  url        = env("DATABASE_URL")
+  extensions = [vector] // Used to save and compare embeddings
 }
 
 model User {
@@ -16,4 +18,17 @@ model User {
   password String
 
   @@map("users")
+}
+
+// PG Extension:  https://github.com/pgvector/pgvector
+// Example query: SELECT * FROM items ORDER BY embedding <-> '[3,1,2]' LIMIT 5;
+// Example on how to insert data with OpenAI: https://github.com/Code42Cate/funding/blob/main/apps/scraper/src/embeddings.ts
+// Example insert: INSERT INTO items (embedding) VALUES ('[1,2,3]'), ('[4,5,6]');
+
+model Items {
+  id        String                 @id @default(cuid())
+  content   String
+  embedding Unsupported("vector")?
+
+  @@map("items")
 }


### PR DESCRIPTION
Implements #22 

- added pgvector to postgres, you can now use embeddings column and search on queries


docs: [pgvector](https://github.com/pgvector/pgvector?tab=readme-ov-file
)
some examples from another project: [Code42Cate/funding](https://github.com/Code42Cate/funding/blob/main/apps/scraper/src/embeddings.ts)