### PR TITLE
feat(admin): add an admin panel to the web app

### DIFF
--- a/apps/web/app/home/admin/page.tsx
+++ b/apps/web/app/home/admin/page.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
+import { Post } from "@/app/home/page";
+import { getProfile, getUnreviewedPosts, reviewPost } from "@/lib/actions";
+import PostContent from "@/components/post/post-content";
+import { Button } from "@ui/components/button";
+import { useToast } from "@ui/components/use-toast";
+import { AnimatePresence, motion } from "framer-motion";
+
+export default function Page() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [file, setFile] = useState<File | null>(null);
+
+  // get unreviewed posts on page load
+  useEffect(() => {
+    getProfile().then((profile) => {
+      if (!profile || profile.type !== "Admin") {
+        window.location.href = "/home";
+      }
+      getUnreviewedPosts().then((posts) => {
+        console.log("posts");
+        setPosts(posts);
+      });
+    });
+  }, []);
+
+  const { toast } = useToast();
+
+  const onSubmitUpload = async (event) => {
+    const endpoint = "https://example.endpoint.com/upload";
+    const formData = new FormData();
+    formData.append("file", file);
+    const response = await fetch(endpoint, {
+      method: "POST",
+      body: formData,
+    });
+    if (response.ok) {
+      toast({
+        title: "Upload successful",
+        description: "Your audio has been uploaded successfully",
+      });
+    } else {
+      toast({
+        title: "Upload failed",
+        description: "Your audio could not be uploaded",
+      });
+    }
+  };
+
+  const handleFileChange = (event: any) => {
+    setFile(event.target.files[0]);
+    // toast
+    toast({
+      title: "File selected",
+      description: "Your file has been selected",
+    });
+  };
+
+  const approvePostFunction = (postId: string) => {
+    return async () => {
+      await reviewPost(postId, "ai_generated_approved");
+      setPosts(posts.filter((post) => post.id !== postId));
+      toast({
+        title: "Post approved",
+        description: "The post has been approved",
+      });
+    };
+  };
+
+  const rejectPostFunction = (postId: string) => {
+    return async () => {
+      await reviewPost(postId, "ai_generated_rejected");
+      setPosts(posts.filter((post) => post.id !== postId));
+      toast({
+        title: "Post rejected",
+        description: "The post has been rejected",
+      });
+    };
+  };
+
+  return (
+    <div className="mt-2 flex w-full flex-col items-center gap-y-8">
+      <div className="mt-8 flex flex-col items-center gap-y-4 lg:mx-0 lg:w-1/3">
+        <h2 className="text-2xl font-bold">Upload new audio</h2>
+        <div className="mx-4 flex w-full cursor-pointer items-center justify-around rounded-xl border p-5 shadow">
+          <form
+            className="flex w-full flex-row items-center justify-between gap-x-4 text-black"
+            onSubmit={onSubmitUpload}
+          >
+            <div className="relative">
+              <input
+                type="file"
+                id="file-upload"
+                className="absolute h-0 w-0"
+                onChange={handleFileChange}
+              />
+              <label
+                htmlFor="file-upload"
+                className="ring-offset-background focus-visible:ring-ring bg-primary text-primary-foreground hover:bg-primary/90 inline-flex h-10 items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
+              >
+                Upload File
+              </label>
+            </div>
+            {file && <span>{file.name}</span>}
+            <Button type="submit">Upload</Button>
+          </form>
+        </div>
+      </div>
+      <div className="mt-4 flex flex-col items-center gap-y-4 lg:mx-0 lg:w-1/3">
+        <h2 className="text-2xl font-bold">Pending reviews for posts</h2>
+        <AnimatePresence>
+          {posts.map((post) => (
+            <motion.div
+              className="w-fill flex flex-col gap-y-2 rounded-xl border p-5 shadow"
+              key={post.id}
+              layoutId={post.id}
+            >
+              <PostContent
+                post={post}
+                type="review"
+                deleteOwnPost={undefined}
+                setDialogOpen={undefined}
+                toggleOwnLike={undefined}
+              />
+              <div className="flex flex-row items-center justify-between gap-4">
+                <Button
+                  className="rounded-lg"
+                  onClick={approvePostFunction(post.id)}
+                >
+                  Approve
+                </Button>
+                <Button
+                  variant="destructive"
+                  className="rounded-lg"
+                  onClick={rejectPostFunction(post.id)}
+                >
+                  Reject
+                </Button>
+              </div>
+            </motion.div>
+          ))}
+          {posts.length === 0 && (
+            <motion.div
+              className="mx-4 w-full cursor-pointer rounded-xl border p-5 shadow"
+              key={"0"}
+              layoutId={"0"}
+            >
+              <span>No posts to review</span>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/home/page.tsx
+++ b/apps/web/app/home/page.tsx
@@ -23,6 +23,7 @@ export type Post = {
   id: string;
   createdAt: Date;
   updatedAt: Date;
+  status: string;
   title: string;
   content: string;
   type: string;

--- a/apps/web/components/post/post-card.tsx
+++ b/apps/web/components/post/post-card.tsx
@@ -18,7 +18,7 @@ export default function PostCard({
   return (
     <DialogTrigger asChild>
       <div
-        className="hover:scale-102  cursor-pointer rounded-xl border p-5 shadow transition ease-in-out hover:shadow-2xl"
+        className="hover:scale-102 cursor-pointer rounded-xl border p-5 shadow transition ease-in-out hover:shadow-2xl"
         onClick={onClick}
       >
         <PostContent

--- a/apps/web/components/post/post-content.tsx
+++ b/apps/web/components/post/post-content.tsx
@@ -7,12 +7,13 @@ import { motion } from "framer-motion";
 
 export default function PostContent({
   post,
+  type,
   deleteOwnPost,
   setDialogOpen,
   toggleOwnLike,
 }: {
   post: Post;
-  type: "create" | "view" | "edit";
+  type: "create" | "view" | "edit" | "review";
   deleteOwnPost: () => void;
   setDialogOpen: (open: boolean) => void;
   toggleOwnLike: () => Promise<boolean>;
@@ -26,7 +27,7 @@ export default function PostContent({
           {post.title}
         </motion.span>
         <div className="flex flex-row gap-4">
-          {status === "authenticated" && (
+          {status === "authenticated" && type !== "review" && (
             <Button
               variant="ghost"
               size="icon"
@@ -50,6 +51,7 @@ export default function PostContent({
             </Button>
           )}
           {status === "authenticated" &&
+            type !== "review" &&
             session.user.email === post.author.email && (
               <Button
                 variant="ghost"
@@ -78,11 +80,13 @@ export default function PostContent({
           <span className="text-base font-normal">by</span>
           <span className="text-base font-bold">{post.author.email}</span>
         </div>
-        <div className="text-base font-normal">
-          <span>{post.likes.length} Likes</span>
-          <span className="mx-2">•</span>
-          <span>{post.comments ? post.comments.length : 0} Comments</span>
-        </div>
+        {type !== "review" && (
+          <div className="text-base font-normal">
+            <span>{post.likes.length} Likes</span>
+            <span className="mx-2">•</span>
+            <span>{post.comments ? post.comments.length : 0} Comments</span>
+          </div>
+        )}
       </motion.div>
       <motion.span className="text-sm font-normal">
         {post.createdAt.toLocaleString()}

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -17,6 +17,7 @@ model User {
   email    String  @unique
   password String
   name     String?
+  type     String  @default("User") // User, Admin
 
   Post    Post[]
   Like    Like[]
@@ -32,6 +33,7 @@ model Post {
   id        String   @id @default(cuid())
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")
+  status    String   @default("user_generated") // user_generated, ai_generated_unreviewed,  ai_generated_approved, ai_generated_rejected
 
   title   String
   content String


### PR DESCRIPTION
You can now review ai generated posts
When going to `/home/admin` you can upload audio files (endpoint still needs to be set).
Also you can see all posts that have the type ai_generated_unreviewed. When adding new ai posts to the db, please now use this type so they show up there. On each post you can click on Accept or Reject which will change the type to `ai_generated_appoved` or `ai_generated_rejected`. If they are accepted they will show up as normal posts on the home page.
You can only access the admin page if you are an Admin, that means `type` for your user is `Admin`. Right now you have to set this manually in the db. For the existing users, everyone is an admin right now.